### PR TITLE
Iris/Eyre: websockets style and logic fixes

### DIFF
--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -3158,7 +3158,6 @@
         ::
         [%websocket-event ws-id=@ event=websocket-event]
         [%websocket-handshake ws-id=@ secure=? =address =request:http]
-
     ==
   :: UIP-125
   :: 
@@ -3176,7 +3175,6 @@
         [%disconnect ~]
         [%message message=websocket-message]
     ==
-
   ::  +origin: request origin as specified in an Origin header
   ::
   +$  origin  @torigin
@@ -3985,7 +3983,6 @@
         ::
         [%websocket-handshake id=@ud url=@t]
         [%websocket-response id=@ud websocket-event:eyre]
-
     ==
   ::
   +$  task
@@ -4012,12 +4009,12 @@
         :: 
         [%cancel-websocket id=@ud]
         ::  receives websocket event from earth
+        ::
         [%websocket-connect app=term url=@t]
         ::  receives websocket event from earth
         ::
         [%websocket-event id=@ud event=websocket-event:eyre]
     ==
-
   ::  UIP-125
   :: 
   +$  websocket-connection

--- a/pkg/arvo/sys/lull.hoon
+++ b/pkg/arvo/sys/lull.hoon
@@ -3085,6 +3085,9 @@
         ::  notification that a cache entry has changed
         ::
         [%grow =path]
+        :: UIP-125
+        ::
+        [%websocket-response wid=@ event=websocket-event]
     ==
   ::
   +$  task
@@ -3151,7 +3154,29 @@
         ::  remember (or update) a cache mapping
         ::
         [%set-response url=@t entry=(unit cache-entry)]
+        :: UIP-125
+        ::
+        [%websocket-event ws-id=@ event=websocket-event]
+        [%websocket-handshake ws-id=@ secure=? =address =request:http]
+
     ==
+  :: UIP-125
+  :: 
+  +$  websocket-connection
+    $:  app=term
+        =inbound-request
+    ==
+  +$  websocket-message
+    $:  opcode=@ud
+        message=(unit data=octs)
+    ==
+  +$  websocket-event
+    $%  [%accept ~]
+        [%reject ~]
+        [%disconnect ~]
+        [%message message=websocket-message]
+    ==
+
   ::  +origin: request origin as specified in an Origin header
   ::
   +$  origin  @torigin
@@ -3956,6 +3981,11 @@
         ::  %response: response to the caller
         ::
         [%http-response =client-response]
+        :: UIP-125
+        ::
+        [%websocket-handshake id=@ud url=@t]
+        [%websocket-response id=@ud websocket-event:eyre]
+
     ==
   ::
   +$  task
@@ -3978,6 +4008,24 @@
         ::  receives http data from outside
         ::
         [%receive id=@ud =http-event:http]
+        :: UIP-125
+        :: 
+        [%cancel-websocket id=@ud]
+        ::  receives websocket event from earth
+        [%websocket-connect app=term url=@t]
+        ::  receives websocket event from earth
+        ::
+        [%websocket-event id=@ud event=websocket-event:eyre]
+    ==
+
+  ::  UIP-125
+  :: 
+  +$  websocket-connection
+    $:  app=term
+        =duct
+        id=@ud
+        url=@t
+        status=?(%pending %accepted)
     ==
   ::  +client-response: one or more client responses given to the caller
   ::

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -96,8 +96,8 @@
       ::
       check-session-timer=_|
       :: UIP 125
+      ::
       sockets=(map @ud websocket-connection)
-
   ==
 ::  channel-request: an action requested on a channel
 ::
@@ -1025,6 +1025,7 @@
       (error-page 404 authenticated url.request ~)
     ==
   ::  WebSockets event
+  ::
   ++  ws-event
     |=  [wid=@ event=websocket-event]
     =/  conn  (~(get by connections.state) duct)
@@ -1040,46 +1041,44 @@
     :: ~&  >>  ws-event=[identity app pat wsid]
     :: TODO damn how
     :: ~&  eyre-ws-event=-.event
-    ?+  -.event  `state
-      %message
-        :_  state
-        :~  %+  deal-as
-            /run-ws-app-request/[wsid]
-            :^  identity  our  app
-            :+  %poke  %websocket-server-message
-            !>([wid u.pat message.event])
-        ==
-      %disconnect
-        =.  connections.state  (~(del by connections.state) duct)
-        :_  state
-        :~  %+  deal-as
-            /ws-watch-response/[wsid]
-            [identity our app %leave ~]
-        ==
+    ?+    -.event  `state
+        %message
+      :_  state
+      :~  %+  deal-as
+          /run-ws-app-request/[wsid]
+          :^  identity  our  app
+          :+  %poke  %websocket-server-message
+          !>([wid u.pat message.event])
+      ==
+    ::
+        %disconnect
+      =.  connections.state  (~(del by connections.state) duct)
+      :_  state
+      :~  %+  deal-as
+          /ws-watch-response/[wsid]
+          [identity our app %leave ~]
+      ==
     ==
+  ::
   ++  ws-handshake
     |=  [wid=@ secure=? =address:eyre =request:http]
     ^-  [(list move) server-state]
-
     =/  host=(unit @t)  (get-header:http 'host' header-list.request)
     =/  [=action suburl=@t]
       (get-action-for-binding host url.request)
     :: TODO enable other actions
     ?.  ?=(%app -.action)  `state
-
-  :: TODO!!  get clear what all the identity thing has to be
+    :: TODO!!  get clear what all the identity thing has to be
     =/  app  app.action
-    =^  ?(invalid=@uv [@uv identity (list move)])  state
+    =^  $@(invalid=@uv [@uv identity (list move)])  state
       (session-for-request:authentication request)
     =/  [session-id=@uv =identity som=(list move)]
-      ?@  -  ~&  invalid-session=-  
-        [invalid [%fake *@p] ~]  -
-
+      ?@  -
+        ~&(invalid-session=invalid [invalid [%fake *@p] ~])
+      -
     =/  authenticated  ?=(%ours -.identity)
-    
     =/  connection=outstanding-connection
-        [action [authenticated secure address request] [session-id identity] ~ 0]
-
+      [action [authenticated secure address request] [session-id identity] ~ 0]
     =.  connections.state
       (~(put by connections.state) duct connection)
     ::  eyre-id is assigned way up in this arm
@@ -1087,17 +1086,14 @@
     :_  state  
     ~&  som=som
     %+  weld  som
-    :~  %+  deal-as
-          /ws-watch-response/[wsid]
+    :~  %+  deal-as  /ws-watch-response/[wsid]
         [identity our app %watch /websocket-server/[wsid]]
       ::
-        %+  deal-as
-          /run-ws-app-request/[wsid]
+        %+  deal-as  /run-ws-app-request/[wsid]
         :^  identity  our  app
         :+  %poke  %websocket-handshake
         !>(`[@ inbound-request:eyre]`[wid inbound-request.connection])
     ==    
-
   ::  +handle-ip: respond with the requester's ip
   ::
   ++  handle-ip
@@ -3156,28 +3152,29 @@
         (subscription-wire channel-id request-id identity.session ship app)
       [identity.session ship app %leave ~]
     --
-
+  ::
   ++  handle-ws-response
     |=  [wid=@ event=websocket-event]
     ^-  [(list move) server-state]    
     =.  connections.state
-      ?:  ?=(%reject -.event)  (~(del by connections.state) duct)
-      ?:  ?=(%disconnect -.event)  (~(del by connections.state) duct)
-      connections.state
+      ?+  -.event  connections.state
+        ?(%reject %disconnect)  (~(del by connections.state) duct)
+      ==
     =.  sockets.state
-      ?:  ?=(%reject -.event)  (~(del by sockets.state) wid)
-      ?:  ?=(%disconnect -.event)  (~(del by sockets.state) wid)
-      ?:  ?=(%accept -.event)
+      ?+    -.event  sockets.state
+          ?(%reject %disconnect)
+        (~(del by sockets.state) wid)
+      ::
+          %accept
         =/  outstanding  (~(get by connections.state) duct)
-        ?~  outstanding  ~&  >>>  eyre-ws-error=[wid event]  sockets.state
+        ?~  outstanding
+          ~&  >>>  eyre-ws-error=[wid event]  sockets.state
         =/  req=inbound-request  inbound-request.u.outstanding
         ::  TODO this is bad
         ?>  ?=(%app -.action.u.outstanding)
-      (~(put by sockets.state) wid +.action.u.outstanding req)
-      sockets.state
-    
+        (~(put by sockets.state) wid +.action.u.outstanding req)
+      ==
     [[duct %give %websocket-response [wid event]]~ state]
-
   ::  +handle-gall-error: a call to +poke-http-response resulted in a %coup
   ::
   ++  handle-gall-error
@@ -3987,12 +3984,12 @@
       ?+    i.wire
           ~|([%bad-take-wire wire] !!)
       ::
-        %run-app-request   run-app-request
-        %watch-response    watch-response
-        %sessions          sessions
-        %channel           channel
-        %acme              acme-ack
-        %conversion-cache  `http-server-gate
+        %run-app-request      run-app-request
+        %watch-response       watch-response
+        %sessions             sessions
+        %channel              channel
+        %acme                 acme-ack
+        %conversion-cache     `http-server-gate
         %run-ws-app-request   run-ws-app-request
         %ws-watch-response    watch-ws-response
       ==
@@ -4000,44 +3997,44 @@
   ++  watch-ws-response
     =/  event-args  [[eny duct now rof] server-state.ax]
     ?>  ?=([@ *] t.wire)
-    ?+  sign  `http-server-gate
-      [%gall %unto %watch-ack *]
-        ?~  p.p.sign
-          ::  received a positive acknowledgment: take no action
-          ::
-          [~ http-server-gate]
-        ::  we have an error; propagate it to the client
+    ?+    sign  `http-server-gate
+        [%gall %unto %watch-ack *]
+      ?~  p.p.sign
+        ::  received a positive acknowledgment: take no action
         ::
-        ~&  gall-error=u.p.p.sign
-        =/  handle-gall-error
-          handle-gall-error:(per-server-event event-args)
-        =^  moves  server-state.ax  (handle-gall-error u.p.p.sign)
-        [moves http-server-gate]
-        :: 
-      [%gall %unto %kick ~]
-        =/  handle-ws-response  handle-ws-response:(per-server-event event-args)
-        =^  moves  server-state.ax
+        [~ http-server-gate]
+      ::  we have an error; propagate it to the client
+      ::
+      ~&  gall-error=u.p.p.sign
+      =/  handle-gall-error
+        handle-gall-error:(per-server-event event-args)
+      =^  moves  server-state.ax  (handle-gall-error u.p.p.sign)
+      [moves http-server-gate]
+    :: 
+        [%gall %unto %kick ~]
+      =/  handle-ws-response  handle-ws-response:(per-server-event event-args)
+      =^  moves  server-state.ax
         :: TODO not great
         =/  wids  (head (flop wire))
         =/  wid  (slav %ud wids)
-          (handle-ws-response wid [%disconnect ~])
-        [moves http-server-gate]
-        ::
-      [%gall %unto %fact *]
-        =/  mark  p.cage.p.sign
-        ?.  ?=(%websocket-response mark)
-          =/  handle-gall-error
-            handle-gall-error:(per-server-event event-args)
-          =^  moves  server-state.ax
-            (handle-gall-error leaf+"eyre bad mark {(trip mark)}" ~)
-          [moves http-server-gate]
-        =/  event  !<([@ websocket-event] q.cage.p.sign)
-        =/  handle-ws-response  handle-ws-response:(per-server-event event-args)
-        =^  moves  server-state.ax
-          (handle-ws-response event)
+        (handle-ws-response wid [%disconnect ~])
       [moves http-server-gate]
-
+    ::
+        [%gall %unto %fact *]
+      =/  mark  p.cage.p.sign
+      ?.  ?=(%websocket-response mark)
+        =/  handle-gall-error
+          handle-gall-error:(per-server-event event-args)
+        =^  moves  server-state.ax
+          (handle-gall-error leaf+"eyre bad mark {(trip mark)}" ~)
+        [moves http-server-gate]
+      =/  event  !<([@ websocket-event] q.cage.p.sign)
+      =/  handle-ws-response  handle-ws-response:(per-server-event event-args)
+      =^  moves  server-state.ax
+        (handle-ws-response event)
+      [moves http-server-gate]
     ==
+  ::
   ++  run-ws-app-request
     
     `http-server-gate
@@ -4529,7 +4526,6 @@
     ==
   ::
       %~2025.10.28
-
     http-server-gate(ax old)
   ::
   ==

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -4286,7 +4286,8 @@
             [date=%~2023.4.11 server-state-3]
             [date=%~2023.5.15 server-state-4]
             [date=%~2024.8.20 server-state-4]
-            [date=%~2025.1.31 server-state]
+            [date=%~2025.1.31 server-state-5]
+            [date=%~2025.10.28 server-state]
         ==
       ::
       +$  server-state-0
@@ -4398,6 +4399,21 @@
             ports=[insecure=@ud secure=(unit @ud)]
             outgoing-duct=duct
             verb=@
+        ==
+      ::
+      +$  server-state-5
+        $:  bindings=(list [=binding =duct =action])
+            cache=(map url=@t [aeon=@ud val=(unit cache-entry)])
+            =cors-registry
+            connections=(map duct outstanding-connection)
+            auth=authentication-state
+            =channel-state
+            domains=(set turf)
+            =http-config
+            ports=[insecure=@ud secure=(unit @ud)]
+            outgoing-duct=duct
+            verb=@
+            check-session-timer=_|
         ==
       --
   |=  old=axle-any
@@ -4518,6 +4534,8 @@
       date.old  %~2025.1.31
       verb.old  [verb.old check-session-timer=&]
     ==
+  ::
+  ::  adds web sockets: UIP-125
   ::
       %~2025.1.31
     %=  $

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -43,7 +43,7 @@
 ++  axle
   $:  ::  date: date at which http-server's state was updated to this data structure
       ::
-      date=%~2025.1.31
+      date=%~2025.10.28
       ::  server-state: state of inbound requests
       ::
       =server-state
@@ -95,6 +95,9 @@
       ::                       who may have been affected by urbit/urbit#7103
       ::
       check-session-timer=_|
+      :: UIP 125
+      sockets=(map @ud websocket-connection)
+
   ==
 ::  channel-request: an action requested on a channel
 ::
@@ -1021,6 +1024,80 @@
       %^  return-static-data-on-duct  404  'text/html'
       (error-page 404 authenticated url.request ~)
     ==
+  ::  WebSockets event
+  ++  ws-event
+    |=  [wid=@ event=websocket-event]
+    =/  conn  (~(get by connections.state) duct)
+    :: ~&  ws-conn=conn
+    ?~  conn  `state
+    ?.  ?=(%app -.action.u.conn)  `state
+    =/  url  url.request.inbound-request.u.conn
+    =/  pat=(unit path)  (rush url stap)
+    ?~  pat  ~&  error-parsing-path=pat  `state
+    =/  app  app.action.u.conn
+    =/  identity  identity.u.conn
+    =/  wsid  (scot %ud wid)
+    :: ~&  >>  ws-event=[identity app pat wsid]
+    :: TODO damn how
+    :: ~&  eyre-ws-event=-.event
+    ?+  -.event  `state
+      %message
+        :_  state
+        :~  %+  deal-as
+            /run-ws-app-request/[wsid]
+            :^  identity  our  app
+            :+  %poke  %websocket-server-message
+            !>([wid u.pat message.event])
+        ==
+      %disconnect
+        =.  connections.state  (~(del by connections.state) duct)
+        :_  state
+        :~  %+  deal-as
+            /ws-watch-response/[wsid]
+            [identity our app %leave ~]
+        ==
+    ==
+  ++  ws-handshake
+    |=  [wid=@ secure=? =address:eyre =request:http]
+    ^-  [(list move) server-state]
+
+    =/  host=(unit @t)  (get-header:http 'host' header-list.request)
+    =/  [=action suburl=@t]
+      (get-action-for-binding host url.request)
+    :: TODO enable other actions
+    ?.  ?=(%app -.action)  `state
+
+  :: TODO!!  get clear what all the identity thing has to be
+    =/  app  app.action
+    =^  ?(invalid=@uv [@uv identity (list move)])  state
+      (session-for-request:authentication request)
+    =/  [session-id=@uv =identity som=(list move)]
+      ?@  -  ~&  invalid-session=-  
+        [invalid [%fake *@p] ~]  -
+
+    =/  authenticated  ?=(%ours -.identity)
+    
+    =/  connection=outstanding-connection
+        [action [authenticated secure address request] [session-id identity] ~ 0]
+
+    =.  connections.state
+      (~(put by connections.state) duct connection)
+    ::  eyre-id is assigned way up in this arm
+    =/  wsid  (scot %ud wid)
+    :_  state  
+    ~&  som=som
+    %+  weld  som
+    :~  %+  deal-as
+          /ws-watch-response/[wsid]
+        [identity our app %watch /websocket-server/[wsid]]
+      ::
+        %+  deal-as
+          /run-ws-app-request/[wsid]
+        :^  identity  our  app
+        :+  %poke  %websocket-handshake
+        !>(`[@ inbound-request:eyre]`[wid inbound-request.connection])
+    ==    
+
   ::  +handle-ip: respond with the requester's ip
   ::
   ++  handle-ip
@@ -3079,6 +3156,28 @@
         (subscription-wire channel-id request-id identity.session ship app)
       [identity.session ship app %leave ~]
     --
+
+  ++  handle-ws-response
+    |=  [wid=@ event=websocket-event]
+    ^-  [(list move) server-state]    
+    =.  connections.state
+      ?:  ?=(%reject -.event)  (~(del by connections.state) duct)
+      ?:  ?=(%disconnect -.event)  (~(del by connections.state) duct)
+      connections.state
+    =.  sockets.state
+      ?:  ?=(%reject -.event)  (~(del by sockets.state) wid)
+      ?:  ?=(%disconnect -.event)  (~(del by sockets.state) wid)
+      ?:  ?=(%accept -.event)
+        =/  outstanding  (~(get by connections.state) duct)
+        ?~  outstanding  ~&  >>>  eyre-ws-error=[wid event]  sockets.state
+        =/  req=inbound-request  inbound-request.u.outstanding
+        ::  TODO this is bad
+        ?>  ?=(%app -.action.u.outstanding)
+      (~(put by sockets.state) wid +.action.u.outstanding req)
+      sockets.state
+    
+    [[duct %give %websocket-response [wid event]]~ state]
+
   ::  +handle-gall-error: a call to +poke-http-response resulted in a %coup
   ::
   ++  handle-gall-error
@@ -3853,6 +3952,14 @@
       %set-response
     =^  moves  server-state.ax  (set-response:server +.task)
     [moves http-server-gate]
+    ::
+      %websocket-event
+    =^  moves  server-state.ax  (ws-event:server +.task)
+    [moves http-server-gate]
+ 
+      %websocket-handshake
+    =^  moves  server-state.ax  (ws-handshake:server +.task)
+    [moves http-server-gate]
   ==
 ::
 ++  take
@@ -3886,7 +3993,55 @@
         %channel           channel
         %acme              acme-ack
         %conversion-cache  `http-server-gate
+        %run-ws-app-request   run-ws-app-request
+        %ws-watch-response    watch-ws-response
       ==
+  ::
+  ++  watch-ws-response
+    =/  event-args  [[eny duct now rof] server-state.ax]
+    ?>  ?=([@ *] t.wire)
+    ?+  sign  `http-server-gate
+      [%gall %unto %watch-ack *]
+        ?~  p.p.sign
+          ::  received a positive acknowledgment: take no action
+          ::
+          [~ http-server-gate]
+        ::  we have an error; propagate it to the client
+        ::
+        ~&  gall-error=u.p.p.sign
+        =/  handle-gall-error
+          handle-gall-error:(per-server-event event-args)
+        =^  moves  server-state.ax  (handle-gall-error u.p.p.sign)
+        [moves http-server-gate]
+        :: 
+      [%gall %unto %kick ~]
+        =/  handle-ws-response  handle-ws-response:(per-server-event event-args)
+        =^  moves  server-state.ax
+        :: TODO not great
+        =/  wids  (head (flop wire))
+        =/  wid  (slav %ud wids)
+          (handle-ws-response wid [%disconnect ~])
+        [moves http-server-gate]
+        ::
+      [%gall %unto %fact *]
+        =/  mark  p.cage.p.sign
+        ?.  ?=(%websocket-response mark)
+          =/  handle-gall-error
+            handle-gall-error:(per-server-event event-args)
+          =^  moves  server-state.ax
+            (handle-gall-error leaf+"eyre bad mark {(trip mark)}" ~)
+          [moves http-server-gate]
+        =/  event  !<([@ websocket-event] q.cage.p.sign)
+        =/  handle-ws-response  handle-ws-response:(per-server-event event-args)
+        =^  moves  server-state.ax
+          (handle-ws-response event)
+      [moves http-server-gate]
+
+    ==
+  ++  run-ws-app-request
+    
+    `http-server-gate
+
   ::
   ++  run-app-request
     ::
@@ -4368,6 +4523,13 @@
     ==
   ::
       %~2025.1.31
+    %=  $
+      date.old  %~2025.10.28
+      check-session-timer.old  [check-session-timer.old sockets=~]
+    ==
+  ::
+      %~2025.10.28
+
     http-server-gate(ax old)
   ::
   ==

--- a/pkg/arvo/sys/vane/eyre.hoon
+++ b/pkg/arvo/sys/vane/eyre.hoon
@@ -1033,8 +1033,9 @@
     ?~  conn  `state
     ?.  ?=(%app -.action.u.conn)  `state
     =/  url  url.request.inbound-request.u.conn
-    =/  pat=(unit path)  (rush url stap)
-    ?~  pat  ~&  error-parsing-path=pat  `state
+    =/  pat=(unit (list @t))
+      (rush url ;~(pfix fas (more fas smeg:de-purl:html)))
+    ?~  pat  ~&(error-parsing-path=url `state)
     =/  app  app.action.u.conn
     =/  identity  identity.u.conn
     =/  wsid  (scot %ud wid)
@@ -1073,9 +1074,8 @@
     =^  $@(invalid=@uv [@uv identity (list move)])  state
       (session-for-request:authentication request)
     =/  [session-id=@uv =identity som=(list move)]
-      ?@  -
-        ~&(invalid-session=invalid [invalid [%fake *@p] ~])
-      -
+      ?^  -  -
+      ~&(invalid-session=invalid [invalid [%fake *@p] ~])
     =/  authenticated  ?=(%ours -.identity)
     =/  connection=outstanding-connection
       [action [authenticated secure address request] [session-id identity] ~ 0]
@@ -3949,11 +3949,11 @@
       %set-response
     =^  moves  server-state.ax  (set-response:server +.task)
     [moves http-server-gate]
-    ::
+  ::
       %websocket-event
     =^  moves  server-state.ax  (ws-event:server +.task)
     [moves http-server-gate]
- 
+  ::
       %websocket-handshake
     =^  moves  server-state.ax  (ws-handshake:server +.task)
     [moves http-server-gate]

--- a/pkg/arvo/sys/vane/iris.hoon
+++ b/pkg/arvo/sys/vane/iris.hoon
@@ -38,7 +38,7 @@
 +$  axle
   $:  ::  date: date at which iris state was updated to this data structure
       ::
-      date=%~2025.7.17
+      date=%~2026.1.1
       ::
       ::
       =state
@@ -46,7 +46,10 @@
 ::  +state:client: state relating to open outbound HTTP connections
 ::
 +$  state
-  $:  ::  next-id: monotonically increasing id number for the next connection
+  $:  ::  sockets: ongoing websocket connections
+      ::
+      sockets=(map @ud websocket-connection)
+      ::  next-id: monotonically increasing id number for the next connection
       ::
       next-id=@ud
       ::  connection-by-id: open connections to the
@@ -328,6 +331,94 @@
       connection-by-id    (~(del by connection-by-id.state) id)
       connection-by-duct  (~(del by connection-by-duct.state) duct.u.con)
     ==
+  ::  UIP-125
+  :: 
+  ++  ws-connect
+    |=  [desk=term url=@t]
+      ~&  iris-ws-connect=[desk url duct]
+
+      ?:  (~(has by connection-by-duct.state) duct)
+      ~&  "cant sent second ws-connect on same duct"  `state
+      :: TODO ... the wid comes from vere tho...?
+      =^  id  next-id.state  [next-id.state +(next-id.state)]
+
+      =/  wc=websocket-connection  [desk duct id url %pending]
+      =.  sockets.state  (~(put by sockets.state) id wc)
+    :: ::  keep track of the duct for cancellation
+
+      :: This sends it to Vere to actually do the request
+      :-  [outbound-duct.state %give %websocket-handshake id url]~
+      state
+  ++  cleanup-ws
+    |=  wid=@ud
+    ^-  [(list move) ^state]
+    ?~  con=(~(get by sockets.state) wid)
+      `state
+    =.  sockets.state  (~(del by sockets.state) wid)
+    :_  state
+    :~  (leave-agent wid app.u.con)
+    ==
+
+  ::  incoming websockets event to be sent BY VERE NOT USERSPACE
+  ++  ws-event
+    |=  [wid=@ud event=websocket-event:eyre]
+      ~&  iris-ws-event=[wid -.event duct]
+      =/  wc  (~(get by sockets.state) wid)
+      ?~  wc  `state
+      =/  wc  u.wc
+      ~&  wc=wc
+      =^  moves  state
+        ?-  -.event
+          %accept
+            =.  wc  wc(status %accepted)
+            =.  sockets.state  (~(put by sockets.state) wid wc)
+            :_  state
+            :~  (watch-agent wid app.wc)                         
+            ==
+          %message  :_  state
+                    :~  (poke-agent [wid +.event] app.wc)
+                    ==
+          %reject  (cleanup-ws wid)
+
+          %disconnect  (cleanup-ws wid)
+        ==
+      =/  m2  (ws-response wc event)
+      [(welp m2 moves) state]
+
+      ++  ws-response
+      |=  [wc=websocket-connection event=websocket-event:eyre]
+        ~&  ws-response=wc
+        :~  :*
+                duct.wc
+                %give
+                %websocket-response
+                id.wc
+                event
+        ==  ==
+      
+  ++  ws-cancel
+    |=  wid=@ud
+    =.  sockets.state  (~(del by sockets.state) wid)
+    :_  state
+    :: TODO this goes to vere
+    :~  [outbound-duct.state %give %cancel-request wid]
+    ==
+  
+  ++  watch-agent
+    |=  [wid=@ud app=term]  ^-  move
+      =/  wids  (scot %ud wid)
+      =/  =note  [%g %deal [our our /iris] app %watch /websocket-client/[wids]]
+      [duct %pass /ws-watch/[wids] note]
+  ++  leave-agent
+    |=  [wid=@ud app=term]  ^-  move
+      ~&  iris-leave-agent=[wid app]
+      =/  wids  (scot %ud wid)
+      =/  =note  [%g %deal [our our /iris] app %leave ~]
+      [duct %pass /ws-watch/[wids] note]
+  ++  poke-agent
+    |=  [msg=[@ud websocket-message:eyre] app=term]  ^-  move
+      =/  =note  [%g %deal [our our /iris] app %poke %websocket-client-message !>(msg)]
+    [duct %pass /iris-ws-poke note]    
   --
 --
 ::  end the =~
@@ -402,6 +493,17 @@
       %receive
     =^  moves  state.ax  (receive:client +.task)
     [moves iris-gate]
+    ::  UIP-125
+  ::
+    %websocket-connect
+    =^  moves  state.ax  (ws-connect:client +.task)
+    [moves iris-gate]
+    %websocket-event
+    =^  moves  state.ax  (ws-event:client +.task)
+    [moves iris-gate]
+    %cancel-websocket
+    =^  moves  state.ax  (ws-cancel:client +.task)
+    [moves iris-gate]
   ==
 ::  http-client issues no requests to other vanes
 ::
@@ -410,7 +512,51 @@
   ^-  [(list move) _iris-gate]
   ~>  %spin.['take/iris']
   ?<  ?=(^ dud)
-  !!
+    :_  iris-gate
+  ?+  wire  ~
+    [%ws-watch wids=@t ~]  =/  wid  (slav %ud wids.wire)
+      ~&  iris-ws-take=-.hin
+      ?+    -.hin  ~
+        %gall
+          ?>  ?=(%unto +<.hin)
+          ~&  hin=-.p.hin
+          ?+    -.p.hin  ~
+            ?(%poke-ack %watch-ack)
+              ?~  p.p.hin  ~
+              ~
+            %kick  
+                =/  event-args  [[eny duct now rof] state.ax]
+                =/  client  (per-client-event event-args)
+                =^  movs  state.ax  (cleanup-ws:client wid)
+                movs
+            %fact
+              =*  cag  cage.p.hin
+              :: This comes from agent, goes to vere
+              ~&  >  iris-take-ws-fact=p.cag
+              ?+    p.cag  ~&(bad-fact+p.cag !!)
+                %message  =/  msg  !<(websocket-message:eyre q.cag)
+                          :~  [outbound-duct.state.ax %give %websocket-response wid %message msg]
+                          ==
+                %disconnect
+                  ~&  iris-take-ws-disconnect=wid
+                  =/  event-args  [[eny duct now rof] state.ax]
+                  =/  client  (per-client-event event-args)
+                  =^  movs  state.ax  (cleanup-ws:client wid)
+                  %+  welp  movs
+                  :~  [outbound-duct.state.ax %give %websocket-response wid %disconnect ~]
+                  ==
+    ::       =/  =tang  !<(tang q.cag)
+    ::       ::  %-  (slog 'khan-fact' tang)
+    ::       :: [hen %give %arow %| p.cag tang]~
+          :: ~
+    ::     ::
+    ::         %thread-done
+    ::       :: [hen %give %arow %& %noun q.cag]~
+    ::       ~
+          ==
+        ==
+      ==
+  ==
 ::
 ++  iris-gate  ..$
 ::  +load: migrate old state to new state (called on vane reload)
@@ -419,7 +565,9 @@
   =>  |%
       +$  axle-any
         $%  [date=%~2019.2.8 state=state-0]
-            [date=%~2025.7.17 =state]
+            [date=%~2025.7.17 =state-1]
+            [date=%~2026.1.1 =state]
+
         ==
       ::
       +$  state-0
@@ -435,6 +583,12 @@
             chunks=(list octs)
             bytes-read=@ud
             expected-size=(unit @ud)
+        ==
+      +$  state-1
+        $:  next-id=@ud
+            connection-by-id=(map @ud [=duct =in-progress-http-request])
+            connection-by-duct=(map duct @ud)
+            outbound-duct=duct
         ==
       --
   |=  old=axle-any
@@ -458,7 +612,13 @@
     +.r(expected-size [expected-size.r *request:http])
     ==
       %~2025.7.17
-    iris-gate(ax old)
+    =/  new-ax=axle
+     :-  %~2026.1.1
+     :-  *(map @ud websocket-connection)
+         state.old
+   iris-gate(ax new-ax)
+      ::
+      %~2026.1.1   iris-gate(ax old)
   ==
 ::  +stay: produce current state
 ::
@@ -470,6 +630,46 @@
   |=  [lyc=gang pov=path car=term bem=beam]
   ^-  (unit (unit cage))
   ~>  %spin.['scry/iris']
+  :: UIP-125
+  :: scry state of open sockets
+  ~&  >>  iris-scry=[lyc=lyc pov=pov car=car bem=bem syd=q.bem]
+  ?.  ?=(%x car)  [~ ~]
+  =/  caller  +<.pov
+  ?:  ?=(%ws q.bem)
+    ~&  iris-ws-scry-id=s.bem
+    ?+  s.bem  ~
+      ~  ``noun+!>(sockets.state.ax)
+
+    [%app ~]
+            =|  conns=(list [wid=@ud url=@t status=$?(%accepted %pending)])
+            =/  sockets  ~(tap by sockets.state.ax)
+            ::  pass a (unit websocket-connection)
+            :-  ~  :-  ~  :-  %noun  !>
+            |-  ?~  sockets  conns
+              =/  socket=websocket-connection:iris  q.i.sockets
+              ?.  .=(app.socket caller)  $(sockets t.sockets)
+                =.  conns  :_  conns  [id.socket url.socket status.socket]
+                $(sockets t.sockets)
+     [%id @ ~]
+        ~&  caller=caller
+        =/  wid  (slav %ud i.t.s.bem)
+        =/  socket  (~(get by sockets.state.ax) wid)
+        ?~  socket  ``noun+!>(~)
+        ?.  .=(app.u.socket caller)  ~
+        ``noun+!>(`[id.u.socket url.u.socket status.u.socket])
+
+    [%url @ ~]
+            =/  sockets  ~(tap by sockets.state.ax)
+            ::  pass a (unit websocket-connection)
+            :-  ~  :-  ~  :-  %noun  !>
+            |-  ?~  sockets  ~
+              =/  socket=websocket-connection:iris  q.i.sockets
+              ?.  .=(app.socket caller)  $(sockets t.sockets)
+              ?:  .=(url.socket i.t.s.bem)  `[id.socket url.socket status.socket]
+              $(sockets t.sockets)
+    ==
+  :: /socket scry
+  :: 
   =*  ren  car
   =*  why=shop  &/p.bem
   =*  syd  q.bem

--- a/pkg/arvo/sys/vane/iris.hoon
+++ b/pkg/arvo/sys/vane/iris.hoon
@@ -335,20 +335,19 @@
   :: 
   ++  ws-connect
     |=  [desk=term url=@t]
-      ~&  iris-ws-connect=[desk url duct]
-
-      ?:  (~(has by connection-by-duct.state) duct)
-      ~&  "cant sent second ws-connect on same duct"  `state
-      :: TODO ... the wid comes from vere tho...?
-      =^  id  next-id.state  [next-id.state +(next-id.state)]
-
-      =/  wc=websocket-connection  [desk duct id url %pending]
-      =.  sockets.state  (~(put by sockets.state) id wc)
-    :: ::  keep track of the duct for cancellation
-
-      :: This sends it to Vere to actually do the request
-      :-  [outbound-duct.state %give %websocket-handshake id url]~
-      state
+    ~&  iris-ws-connect=[desk url duct]
+    ?:  (~(has by connection-by-duct.state) duct)
+      ~&  "cant sent second ws-connect on same duct"
+      `state
+    :: TODO ... the wid comes from vere tho...?
+    =^  id  next-id.state  [next-id.state +(next-id.state)]
+    =/  wc=websocket-connection  [desk duct id url %pending]
+    =.  sockets.state  (~(put by sockets.state) id wc)
+    ::  keep track of the duct for cancellation
+    :: This sends it to Vere to actually do the request
+    :_  state
+    [outbound-duct.state %give %websocket-handshake id url]~
+  ::
   ++  cleanup-ws
     |=  wid=@ud
     ^-  [(list move) ^state]
@@ -358,66 +357,73 @@
     :_  state
     :~  (leave-agent wid app.u.con)
     ==
-
   ::  incoming websockets event to be sent BY VERE NOT USERSPACE
+  ::
   ++  ws-event
     |=  [wid=@ud event=websocket-event:eyre]
-      ~&  iris-ws-event=[wid -.event duct]
-      =/  wc  (~(get by sockets.state) wid)
-      ?~  wc  `state
-      =/  wc  u.wc
-      ~&  wc=wc
-      =^  moves  state
-        ?-  -.event
-          %accept
-            =.  wc  wc(status %accepted)
-            =.  sockets.state  (~(put by sockets.state) wid wc)
-            :_  state
-            :~  (watch-agent wid app.wc)                         
-            ==
-          %message  :_  state
-                    :~  (poke-agent [wid +.event] app.wc)
-                    ==
-          %reject  (cleanup-ws wid)
-
+    ~&  iris-ws-event=[wid -.event duct]
+    =/  wc  (~(get by sockets.state) wid)
+    ?~  wc  `state
+    =/  wc  u.wc
+    ~&  wc=wc
+    =^  moves  state
+      ?-    -.event
+          %reject      (cleanup-ws wid)
           %disconnect  (cleanup-ws wid)
+      ::
+          %accept
+        =.  wc  wc(status %accepted)
+        =.  sockets.state  (~(put by sockets.state) wid wc)
+        :_  state
+        :~  (watch-agent wid app.wc)                         
         ==
-      =/  m2  (ws-response wc event)
-      [(welp m2 moves) state]
-
-      ++  ws-response
-      |=  [wc=websocket-connection event=websocket-event:eyre]
-        ~&  ws-response=wc
-        :~  :*
-                duct.wc
-                %give
-                %websocket-response
-                id.wc
-                event
-        ==  ==
-      
+      ::
+          %message
+        :_  state
+        :~  (poke-agent [wid +.event] app.wc)
+        ==
+      ==
+    =/  m2  (ws-response wc event)
+    [(welp m2 moves) state]
+  ::
+  ++  ws-response
+    |=  [wc=websocket-connection event=websocket-event:eyre]
+    ^-  (list move)
+    ~&  ws-response=wc
+    :~  :*  duct.wc
+            %give
+            %websocket-response
+            id.wc
+            event
+    ==  ==
+  ::    
   ++  ws-cancel
     |=  wid=@ud
     =.  sockets.state  (~(del by sockets.state) wid)
     :_  state
     :: TODO this goes to vere
-    :~  [outbound-duct.state %give %cancel-request wid]
-    ==
-  
+    [outbound-duct.state %give %cancel-request wid]~
+  ::
   ++  watch-agent
-    |=  [wid=@ud app=term]  ^-  move
-      =/  wids  (scot %ud wid)
-      =/  =note  [%g %deal [our our /iris] app %watch /websocket-client/[wids]]
-      [duct %pass /ws-watch/[wids] note]
+    |=  [wid=@ud app=term]
+    ^-  move
+    =/  wids  (scot %ud wid)
+    =/  =note  [%g %deal [our our /iris] app %watch /websocket-client/[wids]]
+    [duct %pass /ws-watch/[wids] note]
+  ::
   ++  leave-agent
-    |=  [wid=@ud app=term]  ^-  move
-      ~&  iris-leave-agent=[wid app]
-      =/  wids  (scot %ud wid)
-      =/  =note  [%g %deal [our our /iris] app %leave ~]
-      [duct %pass /ws-watch/[wids] note]
+    |=  [wid=@ud app=term]
+    ^-  move
+    ~&  iris-leave-agent=[wid app]
+    =/  wids  (scot %ud wid)
+    =/  =note  [%g %deal [our our /iris] app %leave ~]
+    [duct %pass /ws-watch/[wids] note]
+  ::
   ++  poke-agent
-    |=  [msg=[@ud websocket-message:eyre] app=term]  ^-  move
-      =/  =note  [%g %deal [our our /iris] app %poke %websocket-client-message !>(msg)]
+    |=  [msg=[@ud websocket-message:eyre] app=term]
+    ^-  move
+    =/  =note
+      [%g %deal [our our /iris] app %poke %websocket-client-message !>(msg)]
     [duct %pass /iris-ws-poke note]    
   --
 --
@@ -495,13 +501,15 @@
     [moves iris-gate]
     ::  UIP-125
   ::
-    %websocket-connect
+      %websocket-connect
     =^  moves  state.ax  (ws-connect:client +.task)
     [moves iris-gate]
-    %websocket-event
+      %websocket-event
+  ::
     =^  moves  state.ax  (ws-event:client +.task)
     [moves iris-gate]
-    %cancel-websocket
+  ::
+      %cancel-websocket
     =^  moves  state.ax  (ws-cancel:client +.task)
     [moves iris-gate]
   ==
@@ -512,50 +520,45 @@
   ^-  [(list move) _iris-gate]
   ~>  %spin.['take/iris']
   ?<  ?=(^ dud)
-    :_  iris-gate
-  ?+  wire  ~
-    [%ws-watch wids=@t ~]  =/  wid  (slav %ud wids.wire)
-      ~&  iris-ws-take=-.hin
-      ?+    -.hin  ~
+  :_  iris-gate
+  ?+    wire  ~
+      [%ws-watch wids=@t ~]
+    =/  wid  (slav %ud wids.wire)
+    ~&  iris-ws-take=-.hin
+    ?+    -.hin  ~
         %gall
-          ?>  ?=(%unto +<.hin)
-          ~&  hin=-.p.hin
-          ?+    -.p.hin  ~
-            ?(%poke-ack %watch-ack)
-              ?~  p.p.hin  ~
-              ~
-            %kick  
-                =/  event-args  [[eny duct now rof] state.ax]
-                =/  client  (per-client-event event-args)
-                =^  movs  state.ax  (cleanup-ws:client wid)
-                movs
-            %fact
-              =*  cag  cage.p.hin
-              :: This comes from agent, goes to vere
-              ~&  >  iris-take-ws-fact=p.cag
-              ?+    p.cag  ~&(bad-fact+p.cag !!)
-                %message  =/  msg  !<(websocket-message:eyre q.cag)
-                          :~  [outbound-duct.state.ax %give %websocket-response wid %message msg]
-                          ==
-                %disconnect
-                  ~&  iris-take-ws-disconnect=wid
-                  =/  event-args  [[eny duct now rof] state.ax]
-                  =/  client  (per-client-event event-args)
-                  =^  movs  state.ax  (cleanup-ws:client wid)
-                  %+  welp  movs
-                  :~  [outbound-duct.state.ax %give %websocket-response wid %disconnect ~]
-                  ==
-    ::       =/  =tang  !<(tang q.cag)
-    ::       ::  %-  (slog 'khan-fact' tang)
-    ::       :: [hen %give %arow %| p.cag tang]~
-          :: ~
-    ::     ::
-    ::         %thread-done
-    ::       :: [hen %give %arow %& %noun q.cag]~
-    ::       ~
-          ==
+      ?>  ?=(%unto +<.hin)
+      ~&  hin=-.p.hin
+      ?+    -.p.hin  ~
+          ?(%poke-ack %watch-ack)
+        ?~  p.p.hin  ~
+        ~
+      ::
+          %kick  
+        =/  event-args  [[eny duct now rof] state.ax]
+        =/  client  (per-client-event event-args)
+        =^  movs  state.ax  (cleanup-ws:client wid)
+        movs
+      ::
+          %fact
+        =*  cag  cage.p.hin
+        :: This comes from agent, goes to vere
+        ~&  >  iris-take-ws-fact=p.cag
+        ?+    p.cag  ~&(bad-fact+p.cag !!)
+            %message
+          =/  msg  !<(websocket-message:eyre q.cag)
+          [outbound-duct.state.ax %give %websocket-response wid %message msg]~
+        ::
+            %disconnect
+          ~&  iris-take-ws-disconnect=wid
+          =/  event-args  [[eny duct now rof] state.ax]
+          =/  client  (per-client-event event-args)
+          =^  movs  state.ax  (cleanup-ws:client wid)
+          %+  welp  movs
+          [outbound-duct.state.ax %give %websocket-response wid %disconnect ~]~
         ==
       ==
+    ==
   ==
 ::
 ++  iris-gate  ..$
@@ -567,7 +570,6 @@
         $%  [date=%~2019.2.8 state=state-0]
             [date=%~2025.7.17 =state-1]
             [date=%~2026.1.1 =state]
-
         ==
       ::
       +$  state-0
@@ -596,29 +598,29 @@
   ~>  %spin.['load/iris']
   ?-    -.old
       %~2019.2.8
-    %=  $
-      date.old  %~2025.7.17
+    %=    $
+        date.old  %~2025.7.17
     ::
-      connection-by-id.state.old
-    %-  ~(run by connection-by-id.state.old)
-    |=  [d=duct r=in-progress-http-request-0]
-    ^-  [duct in-progress-http-request]
-    :-  d
-    ::  set remaining redirects to 0 because we don't have the original request.
-    ::  it's safe to bunt the .request because it only gets used if
-    ::  .remaining-redirects is non-zero.
-    ::
-    :-  remaining-redirects=0
-    +.r(expected-size [expected-size.r *request:http])
+        connection-by-id.state.old
+      %-  ~(run by connection-by-id.state.old)
+      |=  [d=duct r=in-progress-http-request-0]
+      ^-  [duct in-progress-http-request]
+      :-  d
+      ::  set remaining redirects to 0 because we don't have the original request.
+      ::  it's safe to bunt the .request because it only gets used if
+      ::  .remaining-redirects is non-zero.
+      ::
+      :-  remaining-redirects=0
+      +.r(expected-size [expected-size.r *request:http])
     ==
+  ::
       %~2025.7.17
     =/  new-ax=axle
-     :-  %~2026.1.1
-     :-  *(map @ud websocket-connection)
-         state.old
-   iris-gate(ax new-ax)
-      ::
-      %~2026.1.1   iris-gate(ax old)
+      [%~2026.1.1 *(map @ud websocket-connection) state.old]
+    iris-gate(ax new-ax)
+  ::
+      %~2026.1.1
+    iris-gate(ax old)
   ==
 ::  +stay: produce current state
 ::
@@ -637,36 +639,42 @@
   =/  caller  +<.pov
   ?:  ?=(%ws q.bem)
     ~&  iris-ws-scry-id=s.bem
-    ?+  s.bem  ~
-      ~  ``noun+!>(sockets.state.ax)
-
-    [%app ~]
-            =|  conns=(list [wid=@ud url=@t status=$?(%accepted %pending)])
-            =/  sockets  ~(tap by sockets.state.ax)
-            ::  pass a (unit websocket-connection)
-            :-  ~  :-  ~  :-  %noun  !>
-            |-  ?~  sockets  conns
-              =/  socket=websocket-connection:iris  q.i.sockets
-              ?.  .=(app.socket caller)  $(sockets t.sockets)
-                =.  conns  :_  conns  [id.socket url.socket status.socket]
-                $(sockets t.sockets)
-     [%id @ ~]
-        ~&  caller=caller
-        =/  wid  (slav %ud i.t.s.bem)
-        =/  socket  (~(get by sockets.state.ax) wid)
-        ?~  socket  ``noun+!>(~)
-        ?.  .=(app.u.socket caller)  ~
-        ``noun+!>(`[id.u.socket url.u.socket status.u.socket])
-
-    [%url @ ~]
-            =/  sockets  ~(tap by sockets.state.ax)
-            ::  pass a (unit websocket-connection)
-            :-  ~  :-  ~  :-  %noun  !>
-            |-  ?~  sockets  ~
-              =/  socket=websocket-connection:iris  q.i.sockets
-              ?.  .=(app.socket caller)  $(sockets t.sockets)
-              ?:  .=(url.socket i.t.s.bem)  `[id.socket url.socket status.socket]
-              $(sockets t.sockets)
+    ?+    s.bem  ~
+        ~   ``noun+!>(sockets.state.ax)
+    ::
+        [%app ~]
+      =|  conns=(list [wid=@ud url=@t status=$?(%accepted %pending)])
+      =/  sockets  ~(tap by sockets.state.ax)
+      ::  pass a (unit websocket-connection)
+      :^  ~  ~  %noun
+      !>
+      |-
+      ?~  sockets  conns
+      =/  socket=websocket-connection:iris  q.i.sockets
+      ?.  =(app.socket caller)  $(sockets t.sockets)
+      =.  conns
+        :_  conns  [id.socket url.socket status.socket]
+      $(sockets t.sockets)
+    ::
+        [%id @ ~]
+      ~&  caller=caller
+      =/  wid  (slav %ud i.t.s.bem)
+      =/  socket  (~(get by sockets.state.ax) wid)
+      ?~  socket  ``noun+!>(~)
+      ?.  =(app.u.socket caller)  ~
+      ``noun+!>(`[id.u.socket url.u.socket status.u.socket])
+    ::
+        [%url @ ~]
+      =/  sockets  ~(tap by sockets.state.ax)
+      ::  pass a (unit websocket-connection)
+      :^  ~  ~  %noun
+      !>
+      |-
+      ?~  sockets  ~
+      =/  socket=websocket-connection:iris  q.i.sockets
+      ?.  =(app.socket caller)  $(sockets t.sockets)
+      ?:  =(url.socket i.t.s.bem)  `[id.socket url.socket status.socket]
+      $(sockets t.sockets)
     ==
   :: /socket scry
   :: 

--- a/pkg/arvo/sys/vane/iris.hoon
+++ b/pkg/arvo/sys/vane/iris.hoon
@@ -30,7 +30,16 @@
           ::
           ::
       $%  [%flog =flog:dill]
-  ==  ==  ==
+      ==  ==
+  ::
+      ::  %g: to gall
+      ::
+      $:  %g
+          ::
+          ::
+      $%  [%deal p=sack q=term r=deal:gall]
+      ==  ==
+  ==
 --
 ::  more structures
 ::
@@ -499,13 +508,13 @@
       %receive
     =^  moves  state.ax  (receive:client +.task)
     [moves iris-gate]
-    ::  UIP-125
+  ::  UIP-125
   ::
       %websocket-connect
     =^  moves  state.ax  (ws-connect:client +.task)
     [moves iris-gate]
-      %websocket-event
   ::
+      %websocket-event
     =^  moves  state.ax  (ws-event:client +.task)
     [moves iris-gate]
   ::

--- a/pkg/arvo/sys/vane/iris.hoon
+++ b/pkg/arvo/sys/vane/iris.hoon
@@ -615,9 +615,10 @@
     ==
   ::
       %~2025.7.17
-    =/  new-ax=axle
-      [%~2026.1.1 *(map @ud websocket-connection) state.old]
-    iris-gate(ax new-ax)
+    %=  $
+      date.old   %~2026.1.1
+      state.old  [*(map @ud websocket-connection) state.old]
+    ==
   ::
       %~2026.1.1
     iris-gate(ax old)
@@ -632,52 +633,6 @@
   |=  [lyc=gang pov=path car=term bem=beam]
   ^-  (unit (unit cage))
   ~>  %spin.['scry/iris']
-  :: UIP-125
-  :: scry state of open sockets
-  ~&  >>  iris-scry=[lyc=lyc pov=pov car=car bem=bem syd=q.bem]
-  ?.  ?=(%x car)  [~ ~]
-  =/  caller  +<.pov
-  ?:  ?=(%ws q.bem)
-    ~&  iris-ws-scry-id=s.bem
-    ?+    s.bem  ~
-        ~   ``noun+!>(sockets.state.ax)
-    ::
-        [%app ~]
-      =|  conns=(list [wid=@ud url=@t status=$?(%accepted %pending)])
-      =/  sockets  ~(tap by sockets.state.ax)
-      ::  pass a (unit websocket-connection)
-      :^  ~  ~  %noun
-      !>
-      |-
-      ?~  sockets  conns
-      =/  socket=websocket-connection:iris  q.i.sockets
-      ?.  =(app.socket caller)  $(sockets t.sockets)
-      =.  conns
-        :_  conns  [id.socket url.socket status.socket]
-      $(sockets t.sockets)
-    ::
-        [%id @ ~]
-      ~&  caller=caller
-      =/  wid  (slav %ud i.t.s.bem)
-      =/  socket  (~(get by sockets.state.ax) wid)
-      ?~  socket  ``noun+!>(~)
-      ?.  =(app.u.socket caller)  ~
-      ``noun+!>(`[id.u.socket url.u.socket status.u.socket])
-    ::
-        [%url @ ~]
-      =/  sockets  ~(tap by sockets.state.ax)
-      ::  pass a (unit websocket-connection)
-      :^  ~  ~  %noun
-      !>
-      |-
-      ?~  sockets  ~
-      =/  socket=websocket-connection:iris  q.i.sockets
-      ?.  =(app.socket caller)  $(sockets t.sockets)
-      ?:  =(url.socket i.t.s.bem)  `[id.socket url.socket status.socket]
-      $(sockets t.sockets)
-    ==
-  :: /socket scry
-  :: 
   =*  ren  car
   =*  why=shop  &/p.bem
   =*  syd  q.bem
@@ -686,7 +641,9 @@
   ::
   ?.  ?=(%& -.why)  ~
   =*  his  p.why
-  ?:  &(?=(%x ren) =(tyl //whey) =([~ ~] lyc))
+  ?.  =([~ ~] lyc))  ~
+  ::
+  ?:  &(?=(%x ren) =(tyl //whey))
     =/  maz=(list mass)
       :~  nex+&+next-id.state.ax
           outbound+&+outbound-duct.state.ax
@@ -695,5 +652,40 @@
           axle+&+ax
       ==
     ``mass+!>(maz)
-  [~ ~]
+  ::
+  ~&  >>  iris-scry=[lyc=lyc pov=pov car=car bem=bem syd=q.bem]
+  ~&  iris-ws-scry-id=tyl
+  ?.  =([%$ our] why)  ~
+  ?.  &(?=(%x ren) ?=(%$ syd))  ~
+  ?+    tyl  ~
+      [%ws ~]   ``noun+!>(sockets.state.ax)
+  ::
+      [%ws app=@ ~]
+    :^  ~  ~  %noun
+    !>  ^-  (list [wid=@ud url=@t status=?(%accepted %pending)])
+    %+  murn  ~(tap by sockets.state.ax)
+    |=  [wid=@ud conn=websocket-connection]
+    ^-  (unit [wid=@ud url=@t status=?(%accepted %pending)]
+    ?.  =(app.tyl app.socket)  ~
+    `[id url status]:conn
+  ::
+      [%ws app=@ %id id=@ ~]
+    =/  wid  (slav %ud id.tyl)
+    ?~  suc=(~(get by sockets.state.ax) wid)
+      ``noun+!>(~)
+    ?.  =(app.u.suc app.tyl)  [~ ~]
+    ``noun+!>(`[id url status]:u.suc)
+  ::
+      [%ws app=@ %url url=@ ~]
+    =/  sockets  ~(tap by sockets.state.ax)
+    ::  pass a (unit websocket-connection)
+    :^  ~  ~  %noun
+    !>
+    |-  ^-  [wid=@ud url=@t status=?(%accepted %pending)]
+    ?~  sockets  ~
+    =/  socket=websocket-connection  q.i.sockets
+    ?.  =(app.socket app.tyl)  $(sockets t.sockets)
+    ?.  =(url.socket url.tyl)  $(sockets t.sockets)
+    `[id url status]:socket
+  ==
 --


### PR DESCRIPTION
This primarily fixes style issues in Iris/Eyre for the Websockets PR.

Additionally, it restructures the scry in Iris so it doesn't skip security checks, and restructures the scry paths to be /ws/[app]/url/[url], etc, so that the desk in the beak is %$ in line with Eyre style, and so it doesn't depend on provenance which only works when requests come from agents.

It also fixes the URL parsing logic to use proper en-purl:html functions producing a (list @t) rather than a simple path parser that will get broken by query parameters and non-@ta characters in URL path elements. Note this means it pokes the handler app with a (list @t) rather than path for the URL, so the nostr agent will have to be changed to accommodate that. Without this change though, URL parsing will be unacceptably fragile.