### PR TITLE
Biblically accurate ames/mesa routing in aqua + gw test threads/lib

### DIFF
--- a/pkg/arvo/app/aqua.hoon
+++ b/pkg/arvo/app/aqua.hoon
@@ -632,6 +632,7 @@
             [/e/http-server/0v1n.2m9vh %live 8.080 `8.445]
             [/a/newt/0v1n.2m9vh %born ~]
             [/d/term/1 %hail ~]
+            [/k/khan/0v1n.2m9vh/1 %born ~]
             :: [/d/term/1 %verb ~]  :: XX uncomment for verbose mode
           ::
             ?:  fake.ae  ~

--- a/pkg/arvo/lib/ph/gw/util.hoon
+++ b/pkg/arvo/lib/ph/gw/util.hoon
@@ -1,0 +1,173 @@
+/+  *ph-io, az=aqua-azimuth
+|%
++$  onchain  (list [peer=@p =life spon=(unit @p) fef=?(~ %turf %is %if)])
+++  start-gw-comet
+  |=  [comet=@p loud=? core=?(%ames %mesa) =onchain]
+  |^
+  =.  onchain  (sort-onchain onchain)
+  =/  m  (strand:rand ,~)
+  ~?  >>  loud  [%gw-aqua "{(cite:title comet)}: init"]
+  ;<  ~  bind:m  %*($ init-ship ship comet, fake |, core core)
+  ~?  >>  loud  [%gw-aqua "{(cite:title comet)}: mount %base"]
+  ;<  ~  bind:m  (mount comet %base)
+  ~?  >>  loud  [%gw-aqua "{(cite:title comet)}: copy %gw agent"]
+  ;<  ~  bind:m  (copy-file comet /app/gw/hoon gw-agent)
+  ~?  >>  loud  [%gw-aqua "{(cite:title comet)}: copy udiff mark"]
+  ;<  ~  bind:m  (copy-file comet /mar/groundwire-udiffs/hoon udiffs-mark)
+  ~?  >>  loud  [%gw-aqua "{(cite:title comet)}: start %gw agent"]
+  ;<  ~  bind:m  (dojo comet "|start %gw")
+  ;<  ~  bind:m  (wait-for-output comet "booted %gw")
+  |-  ^-  form:m
+  =*  loop  $
+  ?~  onchain
+    (pure:m ~)
+  ~?  >>  loud  [%gw-aqua "{(cite:title comet)}: inject udiffs for {(cite:title peer.i.onchain)}"]
+  ;<  ~  bind:m  (poke-udiffs i.onchain)
+  ;<  ~  bind:m  (wait-for-output comet ":gw &groundwire-udiffs")
+  loop(onchain t.onchain)
+  ::
+  ++  sort-onchain
+    |=  cha=^onchain
+    ^-  ^onchain
+    %+  sort  cha
+    |=  $:  a=[peer=@p =life spon=(unit @p) fef=*]
+            b=[peer=@p =life spon=(unit @p) fef=*]
+        ==
+    |(?=(~ spon.a) ?=(^ spon.b))
+  ::
+  ++  poke-udiffs
+    |=  $:  for=@p
+            =life
+            spon=(unit @p)
+            fef=?(~ %turf %is %if)
+        ==
+    =/  m  (strand:rand ,~)
+    ^-  form:m
+    =/  =pass  pub:ex:(get-keys:az for life)
+    =/  =udiffs:point:jael
+      :~  (keys-udiff for life)
+          (fief-udiff for fef)
+          (rift-udiff for)
+          (spon-udiff for ?~(spon `for spon))
+      ==
+    (poke-app comet %gw %groundwire-udiffs udiffs)
+  ::
+  ++  spon-udiff
+    |=  [for=@p spon=(unit @p)]
+    ^-  [=ship =udiff:point:jael]
+    [for *id:block:jael %spon spon]
+  ::
+  ++  rift-udiff
+    |=  for=@p
+    ^-  [=ship =udiff:point:jael]
+    [for *id:block:jael %rift 0 %.y]
+  ::
+  ++  keys-udiff
+    |=  [for=@p =life]
+    ^-  [=ship =udiff:point:jael]
+    =/  =pass  pub:ex:(get-keys:az for life)
+    =/  =key-update:point:jael  [life (sub (^end 3 pass) 'a') pass]
+    [for *id:block:jael %keys key-update %.y]
+  ::
+  ++  fief-udiff
+    |=  [for=@p opt=?(~ %turf %is %if)]
+    ^-  [=ship =udiff:point:jael]
+    :^  for  *id:block:jael  %fief
+    ^-  (unit fief)
+    ?-    opt
+        ~    ~
+        %is  ~
+        %turf
+      ?~  got=(~(get by turfs) for)
+        ~
+      `[%turf ~[u.got] *@udE]
+    ::
+        %if
+      =/  index=(unit @ud)  (find ~[for] comets)
+      ?~  index
+        ~
+      `[%if `@`0xdead.beef u.index]
+    ==
+  ::
+  ++  turfs
+    ^~  ^-  (map @p turf)
+    %-  ~(gas by *(map @p turf))
+    ^-  (list [@p turf])
+    =-  (zip:az comets -)
+    ^-  (list turf)
+    :~  /marbud/fasteg  /marbud/daldyl  /marbud/dansyr
+        /marbud/harrep  /marbud/liblyn  /marbud/hidreb
+        /mardev/molpyx  /mardev/fosnys  /mardev/tonmep
+        /mardev/holwyx  /mardev/hacmet  /mardev/ribmut
+    ==
+  ::
+  ++  comets
+    ^-  (list @p)
+    :~  :: marbud, %c suite
+        ~fasteg-dinhet-malrum-ransub--hocduc-digtev-radsut-marbud
+        ~daldyl-nildem-dispec-tilryx--dondus-dirmet-tintyl-marbud
+        ~dansyr-ponbec-tocfel-laddux--socnut-nisnyx-dinsut-marbud
+        :: marbud, %b suite
+        ~harrep-podpec-torsut-docnyx--mopsyx-fosdus-ladpen-marbud
+        ~liblyn-togrut-tabwel-hodbet--dovbex-parryt-mirbyt-marbud
+        ~hidreb-naptev-banben-bicrup--massup-dantus-fodwet-marbud
+        :: mardev, %c suite
+        ~molpyx-novtyc-wortyc-noswyd--taltyv-loplev-dabwen-mardev
+        ~fosnys-noctyd-talfyl-borryl--davhus-disbyn-fotnec-mardev
+        ~tonmep-tabrux-rinbep-firmur--silmex-saldef-pasfer-mardev
+        :: mardev, %b suite
+        ~holwyx-ramped-tognet-barsyn--navler-ronmeg-topbex-mardev
+        ~hacmet-doslyr-narhut-tiptec--micbyl-motnev-worsyn-mardev
+        ~ribmut-nopdul-minmet-pardeg--wisfex-rosfus-fogsyn-mardev
+    ==
+  ::
+  ++  gw-agent
+    '''
+    /+  default-agent
+    ^-  agent:gall
+    |_  =bowl:gall
+    +*  this  .
+        def   ~(. (default-agent this %.n) bowl)
+    ++  on-init
+      ^-  (quip card:agent:gall _this)
+      :_  this
+      [%pass /listen %arvo %j %listen ~ %| %gw]~
+    ++  on-poke
+      |=  [=mark =vase]
+      ^-  (quip card:agent:gall _this)
+      ?>  ?=(%groundwire-udiffs mark)
+      =+  !<(=udiffs:point:jael vase)
+      :_  this
+      [%give %fact ~[/] %groundwire-udiffs !>(udiffs)]~
+    ++  on-watch
+      |=  =path
+      ~&  [%gw %on-watch path=path]
+      ^-  (quip card:agent:gall _this)
+      ?>  ?=(~ path)
+      `this
+    ++  on-save   on-save:def
+    ++  on-load   on-load:def
+    ++  on-leave  on-leave:def
+    ++  on-agent  on-agent:def
+    ++  on-peek   on-peek:def
+    ++  on-arvo   on-arvo:def
+    ++  on-fail   on-fail:def
+    --
+    '''
+  ::
+  ++  udiffs-mark
+    '''
+    |_  dis=udiffs:point:jael
+    ++  grab
+      |%
+      ++  noun  udiffs:point:jael
+      --
+    ++  grow
+      |%
+      ++  noun  dis
+      --
+    ++  grad  %noun
+    --
+    '''
+  --
+--

--- a/pkg/arvo/ted/aqua/ames.hoon
+++ b/pkg/arvo/ted/aqua/ames.hoon
@@ -10,10 +10,55 @@
 /=  ames-raw  /sys/vane/ames
 =,  aquarium
 |%
+::  $fiefs: fiefs emitted by ships
+::
 +$  fiefs  (map ship fiefs-result:jael)
+::
+::  $pit-map: mesa pending interest table
+::
++$  pit-map  (jug mesa-key lane:pact:ames)
++$  mesa-key        [at=ship =name:pact:ames]
++$  mesa-pit-entry  (set lane:pact:ames)
+::  $mesa-pending: outbound request tracker
+::
++$  mesa-pending  (set mesa-key)
+::  $saxos: sponsor ship chain from %saxo effects
+::
++$  saxos  (jar ship ship)
+::
+::  $nails: lanes from %nail effects
+::
++$  nails  (map nail-key nail-entry)
++$  nail-key    [at=ship target=ship]
++$  nail-entry  [ames=(list lane:ames) mesa=(list lane:pact:ames)]
+::  $knowns: whether shot receiver knows shot sender for event n
+::
++$  knowns  (map @ud ?)
+::  $pending-sends:  %send's awaiting knownness check
+::
++$  pending-sends  (map @ud [sndr=@p way=wire %send lan=lane:ames pac=@])
+::  $get-known-queue: queue of knownness check threads
+::
++$  get-known-queue  (jar @p [event-id=@ud shot-sndr=@p shot-rcvr=@p])
+::  $next-id:  next event id to use
+::
++$  next-id  @ud
+::
++$  state
+  $:  fez=fiefs
+      pit=pit-map
+      mep=mesa-pending
+      sax=saxos
+      nas=nails
+      kno=knowns
+      pen=pending-sends
+      keu=get-known-queue
+      nid=next-id
+  ==
 --
 ::
-=|  fez=fiefs
+=|  state
+=*  state  -
 ::
 |%
 ++  emit-aqua-events
@@ -21,100 +66,414 @@
   ^-  (list card:agent:gall)
   [%pass /aqua-events %agent [our %aqua] %poke %aqua-events !>(aes)]~
 ::
+++  handle-saxo
+  |=  [our=ship who=ship way=wire %saxo spons=(list ship)]
+  ^-  (quip card:agent:gall _state)
+  ?~  spons
+    `state(sax (~(del by sax) who))
+  `state(sax (~(put by sax) who spons))
+::
+++  handle-nail
+  |=  [our=ship who=ship way=wire %nail target=ship lanes=(list lane:ames)]
+  ^-  (quip card:agent:gall _state)
+  ?~  lanes
+    `state(nas (~(del by nas) [who target]))
+  =.  nas
+    %+  ~(put by nas)  [who target]
+    [lanes (turn lanes ames-to-mesa-lane)]
+  `state
+::
 ++  handle-fief
   |=  [our=ship who=ship way=wire %fief =fiefs-result:jael]
-  ^-  (quip card:agent:gall fiefs)
+  ^-  (quip card:agent:gall _state)
   :-  ~
-  %+  ~(put by fez)  who
-  (~(uni by (~(gut by fez) who ~)) fiefs-result)
+  %=    state
+      fez
+    %+  ~(put by fez)  who
+    (~(uni by (~(gut by fez) who ~)) fiefs-result)
+  ==
 ::
 ++  handle-restore
   |=  [our=ship who=@p]
-  ^-  (quip card:agent:gall fiefs)
-  :_  fez
+  ^-  (quip card:agent:gall _state)
+  :_  state
   %+  emit-aqua-events  our
   [%event who [/a/newt/0v1n.2m9vh %born ~]]~
+::  +handle-avow: handle knownness thread result
+::
+++  handle-avow
+  |=  [our=@p who=@p way=wire %avow =(avow:khan page)]
+  ^-  (quip card:agent:gall _state)
+  ?.  ?=([@ @ @ @ ~] way)
+    `state
+  =/  event-id=@ud  (slav %ud i.t.t.t.way)
+  ?:  ?=(%| -.avow)                     ::  shouldn't happen
+    `state
+  ?~  queue=(flop (~(get ja keu) who))  ::  shouldn't happen
+    `state
+  ?.  =(event-id event-id.i.queue)      ::  shouldn't happen
+    `state
+  ?~  got=(~(get by pen) event-id)      ::  shouldn't happen
+    `state
+  ?~  known=;;((soft ?) q.p.avow)       ::  shouldn't happen
+    `state
+  =.  pen  (~(del by pen) event-id)
+  =.  kno  (~(put by kno) event-id u.known)
+  =.  keu  (~(put by keu) who (flop t.queue))
+  (handle-send our u.got(way /newt/0v1n.2m9vh/(scot %ud event-id)))
 ::
 ++  handle-send
   =,  ames
-  |=  [our=ship now=@da sndr=@p way=wire %send lan=lane pac=@]
-  ^-  (quip card:agent:gall fiefs)
-  :_  fez
+  |=  [our=ship sndr=@p way=wire %send lan=lane pac=@]
+  ^-  (quip card:agent:gall _state)
   =/  rcvr=(unit @p)  (lane-to-ship sndr lan)
   ?~  rcvr
-    ~&([%aqua %ames %error "can't resolve lane"] ~)
+    ~&([%aqua %ames %handle-send "can't resolve lane"] `state)
   =/  hear-lane  (ship-to-lane sndr)
   =/  =shot      (sift-shot pac)
   ?:  &(!sam.shot req.shot)  :: is fine request
+    ::  TODO: this skips intermediate hops
     =/  [%0 =peep]  (sift-wail `@ux`content.shot)
+    :_  state
     %+  emit-aqua-events  our
     :_  ~
     :-  %read
     [[[u.rcvr rcvr-tick.shot] path.peep] [hear-lane sndr-tick.shot] num.peep]
-  =+  ^=  peers
-      ;;  (unit (map ship ?(%alien %known)))
-      .^  *
-          %gx
-          (scot %p our)
-          %aqua
-          (scot %da now)
-          /i/(scot %p u.rcvr)/ax/(scot %p u.rcvr)//(scot %da now)/peers/noun
-      ==
-  =/  is-known=?
-    ?.  ?=(^ peers)  |
-    =+  peer=(~(get by u.peers) sndr)
-    ?.  ?=(^ peer)  |
-    =(%known u.peer)
-  ?:  ?&  :: =-  ~?  -  %is-pawn
-          ::     -
-          ?|  ?=(%pawn (clan:title sndr))
-              ?=(%pawn (clan:title sndr.shot))
-          ==
-          ::  if this is going to be forwarded, skip checks
-          ::
-          :: =-  ~?  -  %not-forwarded
-          ::     -
-          =(u.rcvr rcvr.shot)
-          =+  ;;(out=(soft [~ signature=@ signed=@]) (mole |.((cue content.shot))))
-          ?|  ?&  ?=(~ out)
-                  ::  if this is not an attestation packet, check that the receiver
-                  ::  has the peer as known
-                  ::
-                  !is-known
-              ==
-              ?&  ?=(^ out)
-                  ?=(^ ;;((soft [~ open-packet:ames-raw]) (mole |.((cue signed:(need (need out)))))))
-                  ::  if this is an attestation packet, check if the rcvr has the comet
-                  ::  as %known -- this is a workaround to prevent a bail:evil that will
-                  ::  end up blocking the queue of the %aqua host, when it tries to decrypt
-                  ::  an open-packet
-                  ::
-                  is-known
-      ==  ==  ==
-    :: ~&  >   "skip packet"^content.shot
-    ~
-  :: ~&  >>   "inject packet"^content.shot
+  =/  event-id=(unit @ud)
+    ?.  ?=([@ @ @ ~] way)  ~
+    `(slav %ud i.t.t.way)
+  =/  is-known=(unit ?)
+    ?~  event-id  ~
+    (~(get by kno) u.event-id)
+  ?:  &(=(u.rcvr rcvr.shot) ?=(~ is-known))
+    (get-known our [sndr.shot rcvr.shot] sndr way %send lan pac)
+  ::  avoid crashes from treating open packet as shut packet or vice versa
+  ::
+  ?:  (known-filter is-known u.rcvr [sndr rcvr content]:shot)
+    ::~&  >  "skip packet"^event-id=event-id
+    :_  state
+    %+  emit-aqua-events  our
+    (next-known-thread rcvr.shot)
+  ::~&  >>   "inject packet"^event-id=event-id
+  :_  state
   %+  emit-aqua-events  our
-  [%event u.rcvr /a/newt/0v1n.2m9vh %hear hear-lane pac]~
+  :_  ?.(=(u.rcvr rcvr.shot) ~ (next-known-thread rcvr.shot))
+  [%event u.rcvr /a/newt/0v1n.2m9vh %hear hear-lane pac]
+  
 ::  XX  this should use the (TODO) message layer in %ames
 ::
 ++  handle-push
   =,  ames
-  |=  [our=ship now=@da sndr=@p way=wire %push lan=(list lane:pact:ames) q=@]
-  ^-  (quip card:agent:gall fiefs)
-  =/  =pact:pact:ames  (parse-packet:ames-raw q)
-  =/  rcvr=ship
-    ?-  +<.pact
-      %peek  her.name.pact
-      %poke  her.ack.pact
-      %page  ?>  ?=(^ lan)
-             ?>  ?=(@ i.lan)
-             `@p`i.lan
+  |=  [our=@p sndr=@p way=wire %push lan=(list lane:pact) q=@]
+  ^-  (quip card:agent:gall _state)
+  =|  aes=(list aqua-event)
+  ::  process each lane with +push-lane and emit the accumulated events
+  ::
+  |-
+  ?~  lan
+    :_  state
+    ?~  aes
+      ~
+    (emit-aqua-events our aes)
+  =^  lan-aes=(list aqua-event)  state
+    (push-lane sndr i.lan q)
+  $(aes (weld lan-aes aes), lan t.lan)
+::
+++  push-lane
+  =,  ames
+  |=  [sndr=@p lan=lane:pact q=@]
+  |^  ^-  [(list aqua-event) _state]
+  =/  pac=pact:pact  (parse-packet:ames-raw q)
+  ?-  +<.pac
+      %peek  (poke-peek-route sndr lan q name.pac pac)
+      %poke  (poke-peek-route sndr lan q ack.pac pac)
+      %page
+    ::  if there's no events emitted, no ship was reached, so discard
+    ::  intermediate state changes
+    ::
+    =-  ?~  aes
+          `state
+        [aes new-state]
+    ^-  [aes=(list aqua-event) new-state=_state]
+    =|  aes=(list aqua-event)
+    =|  last-hop=(unit ship)
+    =/  this-hop=ship  sndr
+    |-
+    ::  pop lanes from pending interest table for this hop
+    ::
+    =/  pits=(list lane:pact)  ~(tap in (~(get ju pit) [this-hop name.pac]))
+    =.  pit  (~(del by pit) [this-hop name.pac])
+    |-
+    ?~  pits
+      ::  are there pending outbound requests?
+      ::
+      ?.  (~(has in mep) [this-hop name.pac])
+        [aes state]
+      =.  mep  (~(del in mep) [this-hop name.pac])
+      ::  if we're the sender, do nothing
+      ::
+      ?~  last-hop
+        [aes state]
+      ::  otherwise, inject
+      ::
+      :_  state
+      :_  aes
+      [%event this-hop /a/newt/0v1n.2m9vh %heer (mesa-ship-to-lane u.last-hop) q]
+    =/  next-hop=(unit @p)  (mesa-lane-to-ship this-hop i.pits)
+    ?~  next-hop
+      $(pits t.pits)
+    ::  update packet routing metadata
+    ::
+    =/  fwd-pac=pact:pact
+      ?~  last-hop  pac
+      pac(hop +(hop.pac), next ~[(mesa-ship-to-lane u.last-hop)])
+    ::  reassemble
+    ::
+    =/  fwd-q=@
+      ?~  last-hop  q
+      p:(fax:plot (en:pact fwd-pac))
+    ::  recurse into next hop
+    ::
+    =^  new-aes=(list aqua-event)  state
+      ?>  ?=(%page +<.fwd-pac)
+      ^$(last-hop `this-hop, this-hop u.next-hop, pac fwd-pac, q fwd-q)
+    ::  update events and move to next PIT lane
+    ::
+    $(pits t.pits, aes new-aes)
+  ==
+  ::
+  ++  poke-peek-route
+    |=  $:  sndr=@p
+            lan=lane:pact
+            q=@
+            key-name=name:pact
+            pac=pact:pact
+        ==
+    ::  if there's no events emitted, no ship was reached, so discard
+    ::  intermediate state changes
+    ::
+    =-  ?~  aes
+          `state
+        [aes new-state]
+    ^-  [aes=(list aqua-event) new-state=_state]
+    =/  target=@p  her.key-name
+    =/  last-hop=@p  sndr
+    =/  this-hop=@p  sndr
+    =/  next=(unit @p)  (mesa-lane-to-ship this-hop lan)
+    ::  if we can't resolve lane, no-op
+    ::
+    ?~  next
+      `state
+    ::  otherwise, add to pending outbound requests
+    ::
+    =.  mep  (~(put in mep) [sndr key-name])
+    ::  move to first hop
+    ::
+    =.  this-hop  u.next
+    =|  aes=(list aqua-event)
+    |-
+    ::  if we've reached the target ship...
+    ::
+    ?:  =(target this-hop)
+      =/  return=lane:pact  (mesa-ship-to-lane last-hop)
+      ::  add to target's PIT
+      ::
+      =.  pit  (~(put ju pit) [this-hop key-name] return)
+      ::  inject event
+      ::
+      :_  state
+      :_  aes
+      [%event this-hop /a/newt/0v1n.2m9vh %heer return q]
+    ::  get sponsor for target from this hop's perspective
+    ::
+    =/  sponsor=@p
+      ::  use default sponsorship chain for azimuth ship
+      ::
+      ?.  (is-c-comet this-hop)
+        ~&  >>>  [%not-c-comet this-hop=this-hop target=target]
+        (rear (^saxo:title target))
+      ::  use emitted saxos for Suite C comets
+      ::
+      =/  saxos=(list @p)  (~(gut by sax) target *(list @p))
+      ?~  saxos
+          ~&  >>>  [%empty-saxos this-hop=this-hop target=target]
+         (rear (^saxo:title target))
+      (rear saxos)
+    ::  make sure we're their sponsor and can therefore forward
+    ::
+    ?.  =(this-hop sponsor)
+      [aes state]
+    ::  get lanes for target from this hop's perspective
+    ::
+    =/  lanes=(list lane:pact)
+      mesa:(~(gut by nas) [this-hop target] *nail-entry)
+    ::  add to this hop's PIT
+    ::
+    =/  return=lane:pact  (mesa-ship-to-lane last-hop)
+    =.  pit  (~(put ju pit) [this-hop key-name] return)
+    |-
+    ?~  lanes
+      [aes state]
+    =/  next-hop=(unit @p)  (mesa-lane-to-ship this-hop i.lanes)
+    ?~  next-hop
+      $(lanes t.lanes)
+    ::  updating packet routing metadata and reassemble
+    ::
+    =/  fwd-pac=pact:pact  pac(hop +(hop.pac))
+    =/  fwd-q=@    p:(fax:plot (en:pact fwd-pac))
+    ::  then give it to the next hop
+    ::
+    =^  new-aes=(list aqua-event)  state
+      ^$(last-hop this-hop, this-hop u.next-hop, pac fwd-pac, q fwd-q)
+    ::  update event list and move to next lane
+    ::
+    $(aes new-aes, lanes t.lanes)
+  --
+::  +known-filter: test whether packet should be injected
+::
+++  known-filter
+  |=  [is-known=(unit ?) rcvr=@p shot-sndr=@p shot-rcvr=@p content=@]
+  ^-  ?
+  ?&  ::=-  ~?  -  %is-pawn
+      ::    -
+      ?=(%pawn (clan:title shot-sndr))
+      ::  if this is going to be forwarded, skip checks
+      ::
+      ::=-  ~?  -  %not-forwarded
+      ::    -
+      =(rcvr shot-rcvr)
+      ::
+      =+  ;;(out=(soft [~ signature=@ signed=@]) (mole |.((cue content))))
+      =+  ;;(open=(soft [~ open-packet:ames-raw]) (mole |.((cue signed:(need (need out))))))
+      ?|  ?&  ?=(~ open)
+              ::  if this is not an attestation packet, check that the receiver
+              ::  has the peer as known
+              ::
+              !?=([~ %.y] is-known)
+          ==
+          ?&  ?=(^ open)
+              ::  if this is an attestation packet, check if the rcvr has the comet
+              ::  as %known -- this is a workaround to prevent a bail:evil that will
+              ::  end up blocking the queue of the %aqua host, when it tries to decrypt
+              ::  an open-packet
+              ::
+              ?=([~ %.y] is-known)
+  ==  ==  ==
+::  +get-known: get known peers before send
+::
+++  get-known
+    |=  $:  our=@p
+            [shot-sndr=@p shot-rcvr=@p]
+            sndr=@p
+            way=wire
+            %send
+            lan=lane:ames
+            pac=@ux
+        ==
+    ^-  (quip card:agent:gall _state)
+    =/  event-id=@ud  nid
+    =.  nid  +(nid)
+    =.  pen  (~(put by pen) event-id [sndr way %send lan pac])
+    ::  if there's a pending thread, wait until complete
+    ::
+    ?^  (~(get ja keu) shot-rcvr)
+      =.  keu  (~(add ja keu) shot-rcvr [event-id shot-sndr shot-rcvr])
+      `state
+    ::  otherwise inject thread
+    ::
+    =.  keu  (~(add ja keu) shot-rcvr [event-id shot-sndr shot-rcvr])
+    =/  fyrd  (make-thread shot-sndr)
+    :_  state
+    %+  emit-aqua-events  our
+    [%event shot-rcvr /k/khan/0v1n.2m9vh/1/(scot %ud event-id) %fyrd fyrd]~
+::  +make-thread: make knownness discovery thread
+::
+++  make-thread
+  |=  shot-sndr=@p
+  ^-  (fyrd:khan cast:khan)
+  =/  =page
+    :-  %ted-eval
+    %-  crip
+    """
+    =/  m  (strand ,vase)
+    ^-  form:m
+    ;<  peers=(map @p ?(%alien %known))  bind:m
+      (scry (map @p ?(%alien %known)) /ax//peers)
+    =/  known=?  
+      =/  peer=?(%alien %known)
+        (~(gut by peers) {(scow %p shot-sndr)} %alien)
+      =(%known peer)
+    (pure:m !>(known))
+    """
+  [%base %khan-eval %noun page]
+::  +next-known-thread: send next queued knownness thread
+::
+++  next-known-thread
+  |=  shot-rcvr=@p
+  ^-  (list aqua-event)
+  ?~  queue=(flop (~(get ja keu) shot-rcvr))
+    ~
+  =/  fyrd  (make-thread shot-sndr.i.queue)
+  [%event shot-rcvr /k/khan/0v1n.2m9vh/1/(scot %ud event-id.i.queue) %fyrd fyrd]~
+::  +is-c-comet: check if a ship is a Suite C comet
+::
+++  is-c-comet
+  |=  ship=@p
+  ^-  ?
+  ?.  ?=(%pawn (clan:title ship))
+    %.n
+  =/  index=(unit @)  (find ~[ship] comets)
+  ?~  index  %.n
+  |((lte u.index 2) &((gte u.index 6) (lte u.index 8)))
+::  +mesa-lane-to-ship: decode a ship from a mesa lane
+::
+::    Special-case some comets, since their addresses doesn't fit into a lane.
+::
+++  mesa-lane-to-ship
+  |=  [sndr=@p =lane:pact:ames]
+  ^-  (unit ship)
+  ?@  lane
+    ?.  =(%pawn (clan:title `@p``@`lane))
+      (some `@p``@`lane)
+    =/  =fiefs-result:jael  (~(gut by fez) sndr ~)
+    ?~  got=(~(gut by fiefs-result) `@p``@`lane *(unit fief))
+      ~
+    ?-    -.u.got
+        %is  ~
+        %turf
+      |-  ^-  (unit ship)
+      ?~  p.u.got  ~
+      ?^  tuf=(~(get by turfs) i.p.u.got)
+        tuf
+      $(p.u.got t.p.u.got)
+    ::
+        %if
+      ?.  =(0xdead.beef p.u.got)  ~
+      ?.  (lth q.u.got 12)  ~
+      (some (snag q.u.got comets))
     ==
-  =/  lan=lane:pact:ames  ?:(?=(%page +<.pact) `@ux`rcvr `@ux`sndr)
-  :_  fez
-  %+  emit-aqua-events  our
-  [%event rcvr /a/newt/0v1n.2m9vh %heer lan q]~
+  ?-  -.lane
+      %is  ~
+  ::
+      %if
+    ?:  ?&  =(0xdead.beef p.lane)
+            (lth q.lane 12)
+        ==
+      (some (snag q.lane comets))
+    (some `@p``@`(cat 5 p.lane q.lane))
+  ==
+::  +mesa-ship-to-lane: encode a lane to look like it came from .ship
+::
+::    Never shows up as a galaxy, because Vere wouldn't know that either.
+::    Special-case a list of comets, since its address doesn't fit into a lane.
+::
+++  mesa-ship-to-lane
+  |=  =ship
+  ^-  lane:pact:ames
+  =/  index=(unit @ud)  (find ~[ship] comets)
+  ?~  index
+    [%if (end 5 ship) (rsh 5 ship)]
+  [%if `@if``@`0xdead.beef u.index]
 ::  +lane-to-ship: decode a ship from an aqua lane
 ::
 ::    Special-case some comets, since their addresses doesn't fit into a lane.
@@ -141,7 +500,7 @@
         %if
       ?.  =(0xdead.beef p.u.got)  ~
       ?.  (lth q.u.got 12)  ~
-      $(lane [%| (cat 5 p.u.got q.u.got)])
+      (some (snag q.u.got comets))
     ==
   ::
       %|
@@ -165,6 +524,15 @@
   ?~  index
     ship
   (cat 2 0xdead.beef u.index)
+::  +ames-to-mesa-lane: convert an ames lane to $lane:pact
+::
+++  ames-to-mesa-lane
+  |=  =lane:ames
+  ^-  lane:pact:ames
+  ?-  -.lane
+      %&  `@ux``@`p.lane
+      %|  [%if (end 5 p.lane) (cut 4 [2 1] p.lane)]
+  ==
 ::  +comets: list of hard-coded comets
 ::
 ++  comets
@@ -213,18 +581,21 @@
     $(out [[i.a i.b] out], a t.a, b t.b)
 --
 ::
-%+  aqua-vane-thread  ~[%fief %restore %send %push]
+%+  aqua-vane-thread  ~[%nail %saxo %fief %restore %send %push %avow]
 |_  =bowl:spider
 +*  this  .
 ++  handle-unix-effect
   |=  [who=@p ue=unix-effect]
   ^-  (quip card:agent:gall _this)
-  =^  cards  fez
-    ?+  -.q.ue  [~ fez]
+  =^  cards  state
+    ?+  -.q.ue  [~ state]
+      %nail     (handle-nail our.bowl who ue)
+      %saxo     (handle-saxo our.bowl who ue)
       %fief     (handle-fief our.bowl who ue)
       %restore  (handle-restore our.bowl who)
-      %send     (handle-send our.bowl now.bowl who ue)
-      %push     (handle-push our.bowl now.bowl who ue)
+      %send     (handle-send our.bowl who ue)
+      %push     (handle-push our.bowl who ue)
+      %avow     (handle-avow our.bowl who ue)
     ==
   [cards this]
 ::

--- a/pkg/arvo/ted/ph/gw/comets-hi.hoon
+++ b/pkg/arvo/ted/ph/gw/comets-hi.hoon
@@ -1,0 +1,20 @@
+/+  *ph-gw-util
+|=  arg=vase
+=/  m  (strand:rand ,vase)
+=/  core=?(%ames %mesa)  (fall !<((unit ?(%ames %mesa)) arg) %ames)
+=/  comet-1  ~fasteg-dinhet-malrum-ransub--hocduc-digtev-radsut-marbud
+=/  comet-2  ~molpyx-novtyc-wortyc-noswyd--taltyv-loplev-dabwen-mardev
+=/  loud  %.n
+::
+;<  ~  bind:m  start-simple
+::
+;<  ~  bind:m  (start-gw-comet comet-1 loud core [comet-2 1 ~ %if]~)
+;<  ~  bind:m  (start-gw-comet comet-2 loud core [comet-1 1 ~ %if]~)
+::
+~?  >>  loud  [%gw-comet-hi "{(cite:title comet-1)}: send hi to {(cite:title comet-2)}"]
+;<  ~  bind:m  (send-hi comet-1 comet-2)
+~?  >>  loud  [%gw-comet-hi "{(cite:title comet-2)}: send hi to {(cite:title comet-1)}"]
+;<  ~  bind:m  (send-hi comet-2 comet-1)
+::
+;<  ~  bind:m  end
+(pure:m *vase)

--- a/pkg/arvo/ted/ph/gw/comets-sponsor.hoon
+++ b/pkg/arvo/ted/ph/gw/comets-sponsor.hoon
@@ -1,0 +1,30 @@
+/+  *ph-gw-util
+|=  arg=vase
+=/  m  (strand:rand ,vase)
+=/  core=?(%ames %mesa)  (fall !<((unit ?(%ames %mesa)) arg) %ames)
+::
+=/  comet-1  ~fasteg-dinhet-malrum-ransub--hocduc-digtev-radsut-marbud
+=/  comet-2  ~daldyl-nildem-dispec-tilryx--dondus-dirmet-tintyl-marbud
+=/  comet-3  ~dansyr-ponbec-tocfel-laddux--socnut-nisnyx-dinsut-marbud
+::
+=/  loud  %.n
+::
+=/  =onchain
+  :~  [peer=comet-1 life=1 spon=`comet-2 fef=~]
+      [peer=comet-2 life=1 spon=~ fef=%if]
+      [peer=comet-3 life=1 spon=~ fef=%if]
+  ==
+::
+;<  ~  bind:m  start-simple
+::
+;<  ~  bind:m  (start-gw-comet comet-1 loud core onchain)
+;<  ~  bind:m  (start-gw-comet comet-2 loud core onchain)
+;<  ~  bind:m  (start-gw-comet comet-3 loud core onchain)
+::
+~?  >>  loud  [%gw-comet-hi "{(cite:title comet-1)}: send hi to {(cite:title comet-2)}"]
+;<  ~  bind:m  (send-hi comet-1 comet-2)
+~?  >>  loud  [%gw-comet-hi "{(cite:title comet-3)}: send hi to {(cite:title comet-1)}"]
+;<  ~  bind:m  (send-hi comet-3 comet-1)
+::
+;<  ~  bind:m  end
+(pure:m *vase)

--- a/pkg/base-dev/lib/ph/io.hoon
+++ b/pkg/base-dev/lib/ph/io.hoon
@@ -163,20 +163,16 @@
   |=  comet=ship
   =/  m  (strand ,~)
   ^-  form:m
-  ::  hardcoded for:
-  ::    ~londeg-tirlys-somlyd-poltus--pintyn-tarbyl-bicnux-marbud
-  ::
   =/  =feed:jael
     :*  [%2 ~]
         who=comet
         ryf=0
         :_  ~
         :-  lyf=1
-        key=0wfm.lBEWM.08gfy.AxYjy.8-tBQ.uq-aa.LZt9c.CVQqd.XBJIs.
-            CoG90.BNNGV.1ZmVi.ZbAhY.LuhwC.idNnU.lCVkt.Z4qug.7iY92
+        key=sec:ex:(get-keys:aqua-azimuth comet 1)
     ==
   ::
-  ?>  ?=(^ (veri:dawn:vere comet feed *point:azimuth-types ~))
+  ?>  ?=(^ (veri:dawn:vere comet feed *point:jael ~ &))
   ~&  >  "mining comet under {<(^sein:title comet)>}"
   ;<  ~  bind:m  (send-events (init:util comet fake=%.n `feed core))
   (check-ship-booted comet)

--- a/pkg/base-dev/sur/aquarium.hoon
+++ b/pkg/base-dev/sur/aquarium.hoon
@@ -75,6 +75,7 @@
       [%push p=(list lane:pact:ames) q=@]
       [%saxo sponsors=(list ship)]
       [%nail =ship lanes=(list lane:ames)]
+      [%avow p=(avow:khan page)]
       [%doze p=(unit @da)]
       [%thus p=@ud q=(unit hiss:eyre)]
       [%ergo p=@tas q=mode:clay]


### PR DESCRIPTION
Run test threads `-ph-gw-comets-sponsor` and `ph-gw-comets-hi`. You can optionally give the argument `%mesa` to either thread to run in directed messaging mode rather than normal ames.