### PR TITLE
ames: add +send-blob-via to fix +fetch-comet-pki/+on-hear-keys routing for non-GW comets

### DIFF
--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -5849,10 +5849,22 @@
             (emit [duct %pass /public-keys %j %public-keys ship ~ ~])
           =.  event-core
             =/  =blob  (sendkeys-packet ship)
-            (send-blob for=| ship blob (~(get by peers.ames-state) ship))
+            =/  sponsor=@p  (^sein:title ship)
+            =/  sponsor-state=(unit ship-state)
+              (~(get by peers.ames-state) sponsor)
+            (send-blob-via for=| sponsor ship blob sponsor-state)
           =/  =wire  /alien/(scot %p ship)
           (emit duct %pass wire %b %wait (add now ~s30))
         ::  +send-blob: fire packet at .ship and maybe sponsors
+        ::
+        ::    Wrapper for +send-blob-via where .ship and .final-ship are
+        ::    the same.
+        ::
+        ++  send-blob
+          ~/  %send-blob
+          |=  [for=? =ship =blob ship-state=(unit ship-state)]
+          (send-blob-via for ship ship blob ship-state)
+        ::  +send-blob-via: fire packet at .final-ship via .ship and maybe sponsors
         ::
         ::    Send to .ship and sponsors until we find a direct lane,
         ::    skipping .our in the sponsorship chain.
@@ -5860,11 +5872,9 @@
         ::    If we have no PKI data for a recipient, enqueue the packet and
         ::    request the information from Jael if we haven't already.
         ::
-        ++  send-blob
-          ~/  %send-blob
-          |=  [for=? =ship =blob ship-state=(unit ship-state)]
-          ::
-          =/  final-ship  ship
+        ++  send-blob-via
+          ~/  %send-blob-via
+          |=  [for=? =ship final-ship=ship =blob ship-state=(unit ship-state)]
           %-  (ev-trace rot.veb final-ship |.("send-blob: to {<ship>}"))
           |-
           |^  ^+  event-core

--- a/pkg/arvo/sys/vane/ames.hoon
+++ b/pkg/arvo/sys/vane/ames.hoon
@@ -4951,9 +4951,17 @@
               |.("requested attestation")
           ?.  =(%pawn (clan:title our))
             event-core
+          =/  via=@p
+            ?.  =(%pawn (clan:title sndr.shot))
+              sndr.shot
+            =/  lyf
+              (rof [~ ~] /ames %j `beam`[[our %lyfe %da now] /(scot %p sndr.shot)])
+            ?:  ?=([~ ~ [* * ^]] lyf)
+              sndr.shot
+            (^sein:title sndr.shot)
           =/  =blob  (attestation-packet sndr.shot 1)
-          %-  send-blob
-          [for=| sndr.shot blob (~(get by peers.ames-state) sndr.shot)]
+          %-  send-blob-via
+          [for=| via sndr.shot blob (~(get by peers.ames-state) via)]
         ::  +on-hear-open: handle receipt of plaintext comet self-attestation
         ::
         ++  on-hear-open


### PR DESCRIPTION
Upstream Ames does this in `+send-blob`:

```hoon
        ++  send-blob
          ~/  %send-blob
          |=  [for=? =ship =blob ship-state=(unit ship-state)]
          ::
          =/  final-ship  ship
          %-  (ev-trace rot.veb final-ship |.("send-blob: to {<ship>}"))
          |-
          |^  ^+  event-core
              =/  chum-state=(unit chum-state)
                (~(get by chums.ames-state) ship)
              ?.  ?|  ?=([~ %known *] chum-state)
                      ?=([~ %known *] ship-state)
                  ==
                ?:  ?=(%pawn (clan:title ship))
                  (try-next-sponsor (^sein:title ship))
```

We removed the "if pawn: try next sponsor" because it would make GW routing not work, but in removing it we inadvertently made it so non-GW ships couldn't route to unknown comets.

In order to fix this, I've changed `+send-blob` to `+send-blob-via`, where `.final-ship` is an explicit argument rather than initially the same as `.ship`. `+send-blob` is retained as a simple wrapper for this and just calls `+send-blob-via` with both `.ship` and `.final-ship` the same, to preserve existing call-sites.

`+fetch-comet-pki` will now directly call `+send-blob-via` with `.final-ship` as the target comet and `.ship` as `(^sein:title comet)`. This is functionally equivalent to the is-pawn test that was removed. The difference is that `+fetch-comet-pki` only does this after first checking we don't already have state in Jael for that comet, so GW comets will still route normally rather than going via the default azimuth sponsor.